### PR TITLE
Enable the Response serialization to support multi-lang RPC-client (excluding the Exception serialization).

### DIFF
--- a/protocol/src/main/java/com/distkv/drpc/proxy/ProxyHandler.java
+++ b/protocol/src/main/java/com/distkv/drpc/proxy/ProxyHandler.java
@@ -1,8 +1,5 @@
 package com.distkv.drpc.proxy;
 
-import com.distkv.drpc.codec.DelayDeserialization;
-import com.distkv.drpc.codec.Serialization;
-import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.util.concurrent.CompletableFuture;
@@ -52,12 +49,7 @@ public class ProxyHandler<T> implements InvocationHandler {
           if (v.getThrowable() != null) {
             future.completeExceptionally(v.getThrowable());
           } else {
-            try {
-              Object completedValue = resolveCompletedValue(v.getValue(), returnType);
-              future.complete(completedValue);
-            } catch (Exception e) {
-              future.completeExceptionally(e);
-            }
+            future.complete(v.getValue());
           }
         }
       });
@@ -69,16 +61,7 @@ public class ProxyHandler<T> implements InvocationHandler {
       throw response.getThrowable();
     }
 
-    return resolveCompletedValue(response.getValue(), returnType);
-  }
-
-  private Object resolveCompletedValue(Object value, Class<?> returnType) throws IOException {
-    if (value instanceof DelayDeserialization) {
-      Serialization serialization = ((DelayDeserialization) value).getSerialization();
-      byte[] data = ((DelayDeserialization) value).getData();
-      return serialization.deserialize(data, returnType);
-    }
-    return value;
+    return response.getValue();
   }
 
   private boolean isLocalMethod(Method method) {

--- a/transport/src/main/java/com/distkv/drpc/codec/DstCodec.java
+++ b/transport/src/main/java/com/distkv/drpc/codec/DstCodec.java
@@ -10,7 +10,6 @@ import com.distkv.drpc.utils.ReflectUtils;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 /**
  * protocol header：

--- a/transport/src/main/java/com/distkv/drpc/codec/DstCodec.java
+++ b/transport/src/main/java/com/distkv/drpc/codec/DstCodec.java
@@ -200,7 +200,7 @@ public class DstCodec implements Codec {
     byte[] data = new byte[header.length + body.length];
     System.arraycopy(header, 0, data, 0, header.length);
     System.arraycopy(body, 0, data, pos, body.length);
-    System.out.println(Arrays.toString(data));
+
     return data;
   }
 

--- a/transport/src/main/java/com/distkv/drpc/codec/DstCodec.java
+++ b/transport/src/main/java/com/distkv/drpc/codec/DstCodec.java
@@ -7,13 +7,8 @@ import com.distkv.drpc.common.Void;
 import com.distkv.drpc.constants.CodecConstants;
 import com.distkv.drpc.exception.CodecException;
 import com.distkv.drpc.utils.ReflectUtils;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInput;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutput;
-import java.io.ObjectOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 


### PR DESCRIPTION
Removed all language bounded serialization like ObjectInputStream/ObjectOutputStream.